### PR TITLE
Uncommented force include

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,9 +22,9 @@ plugins:
 custom:
   webpack:
     keepOutputDirectory: true
-    # includeModules:
-    #   forceInclude:
-    #     - vm2
+    includeModules:
+      forceInclude:
+        - vm2
     # webpackConfig: 'webpack.config.js' # Name of webpack configuration file
     # includeModules: false # Node modules configuration for packaging
     # packager: 'npm' # Packager that will be used to package your external modules


### PR DESCRIPTION
**Problem**: Without force include uncommented the code was built, and it ran locally. However, it failed when it was deployed to AWS Lambda. 

**Solution**: Uncomment in `webpack.config.js`
```
custom:
  webpack:
    includeModules:
      forceInclude:
        - vm2
```